### PR TITLE
Added Ellipse-D default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Default config file for an Ellipse-E with an external antenna and external Gnss.
 * **ellipse_N_default.yaml** <br />
 Default config file for an Ellipse-N with an external antenna and internal Gnss.
 
+* **ellipse_D_default.yaml** <br />
+Default config file for an Ellipse-D with an internal dual-antenna Gnss.
+
+
 ## Launch files
 ### Default launch files
 * **sbg_device.launch** <br />

--- a/config/example/ellipse_A_default.yaml
+++ b/config/example/ellipse_A_default.yaml
@@ -80,8 +80,8 @@ imuAlignementLeverArm:
 
 # AIDING_ASSIGNMENT
 # Note: GNSS1 module configuration can only be set to an external port on Ellipse-E version.
-# Ellipse-N users must set this module to MODULE_INTERNAL. On the other hand, rtcmModule is only
-# available for Ellipse-N users. This module must be set to MODULE_DISABLED for other users.
+# Ellipse-N and Ellipse-D users must set this module to MODULE_INTERNAL. On the other hand, rtcmModule is only
+# available for Ellipse-N and Ellipse-D users. This module must be set to MODULE_DISABLED for other users.
 aidingAssignment:
   # GNSS module port assignment:
   # 255 Module is disabled

--- a/config/example/ellipse_D_default.yaml
+++ b/config/example/ellipse_D_default.yaml
@@ -11,7 +11,7 @@ confWithRos: true
 
 uartConf:
   # Port Name
-  portName: "/dev/ttyUSB0"
+  portName: "/dev/sbg"
 
   # Baude rate (4800 ,9600 ,19200 ,38400 ,115200 [default],230400 ,460800 ,921600)
   baudRate: 115200
@@ -89,7 +89,7 @@ aidingAssignment:
   # 2 Module connected on PORT_C
   # 3 Module connected on PORT_D
   # 5 Module is connected internally
-  gnss1ModulePortAssignment: 2
+  gnss1ModulePortAssignment: 5
   # GNSS module sync assignment:
   # 0 Module is disabled
   # 1 Synchronization is done using SYNC_IN_A pin
@@ -99,8 +99,8 @@ aidingAssignment:
   # 5 Synchronization is internal
   # 6 Synchronization is done using SYNC_OUT_A pin
   # 7 Synchronization is done using SYNC_OUT_B pin
-  gnss1ModuleSyncAssignment: 0
-  # RTCM input port assignment for Ellipse-N DGPS (see gnss1ModulePortAssignment for values)
+  gnss1ModuleSyncAssignment: 5
+  # RTCM input port assignment for Ellipse-D DGPS (see gnss1ModulePortAssignment for values)
   rtcmPortAssignment: 255
   # Odometer module pin assignment
   # 0 Odometer is disabled
@@ -147,7 +147,7 @@ gnss:
   # 104 Used on Ellipse-E to setup a connection to ublox in read only mode.
   # 106 Used on Ellipse-E to setup a connection to Novatel receiver in read only mode.
   # 107 Used on Ellipse-D by default
-  gnss_model_id: 102
+  gnss_model_id: 107
 
   #GNSS primary antenna lever arm in IMU X axis (m)
   primaryLeverArmX: 0
@@ -231,24 +231,24 @@ output:
   # 1 The system will be synchronized on the clock input observed at SYNC_IN_A pin.
   # 2 The system will be synchronized GPS PPS signal, (see GPS module assignment)
   timeReference: 0
-  ros_standard: false
+  ros_standard: true
 
   # Status general, clock, com aiding, solution, heave
   log_status: 8
   # Includes IMU status, acc., gyro, temp delta speeds and delta angles values
   log_imu_data: 8
   # Includes roll, pitch, yaw and their accuracies on each axis
-  log_ekf_euler: 8
+  log_ekf_euler: 0
   # Includes the 4 quaternions values
   log_ekf_quat: 0
   # Position and velocities in NED coordinates with the accuracies on each axis
-  log_ekf_nav: 8
+  log_ekf_nav: 0
   # Heave, surge and sway and accelerations on each axis for up to 4 points
-  log_ship_motion: 8
+  log_ship_motion: 0
   # Provides UTC time reference
   log_utc_time: 8
   # Magnetic data with associated accelerometer on each axis
-  log_mag: 8
+  log_mag: 0
   # Magnetometer calibration data (raw buffer)
   log_mag_calib: 0
   # GPS velocities from primary or secondary GPS receiver
@@ -267,10 +267,10 @@ output:
   log_event_c: 0
   log_event_d: 0
   # Air data
-  log_air_data: 8
+  log_air_data: 0
   # Short IMU data
   log_imu_short: 0
 
   # Node frequency (Hz) (if set to 0, the node will decide the most appropriate frequency to run)
   frequency: 0
-
+  

--- a/config/example/ellipse_N_default.yaml
+++ b/config/example/ellipse_N_default.yaml
@@ -80,8 +80,8 @@ imuAlignementLeverArm:
 
 # AIDING_ASSIGNMENT
 # Note: GNSS1 module configuration can only be set to an external port on Ellipse-E version.
-# Ellipse-N users must set this module to MODULE_INTERNAL. On the other hand, rtcmModule is only
-# available for Ellipse-N users. This module must be set to MODULE_DISABLED for other users.
+# Ellipse-N and Ellipse-D users must set this module to MODULE_INTERNAL. On the other hand, rtcmModule is only
+# available for Ellipse-N and Ellipse-D users. This module must be set to MODULE_DISABLED for other users.
 aidingAssignment:
   # GNSS module port assignment:
   # 255 Module is disabled
@@ -273,3 +273,4 @@ output:
 
   # Node frequency (Hz) (if set to 0, the node will decide the most appropriate frequency to run)
   frequency: 0
+  

--- a/launch/examples/sbg_ellipseD.launch
+++ b/launch/examples/sbg_ellipseD.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node name="sbg_ellipseD" pkg="sbg_driver" type="sbg_device" output="screen">
+  	<rosparam command="load" file="$(find sbg_driver)/config/example/ellipse_D_default.yaml" />
+  </node>
+</launch>


### PR DESCRIPTION
There are no Ellipse-D default config and launch files present, so it might be useful for Ellipse-D users.