### PR TITLE
Fix #52 Fix duplicated stamp

### DIFF
--- a/include/sbg_driver/message_publisher.h
+++ b/include/sbg_driver/message_publisher.h
@@ -221,12 +221,11 @@ public:
   /*!
    * Publish the received SbgLog if the corresponding publisher is defined.
    * 
-   * \param[in] ref_ros_time            ROS processing time for the messages.
    * \param[in] sbg_msg_class           Class ID of the SBG message.
    * \param[in] sbg_msg_id              Id of the SBG message.
    * \param[in] ref_sbg_log             SBG binary log.
    */
-  void publish(const ros::Time& ref_ros_time, SbgEComClass sbg_msg_class, SbgEComMsgId sbg_msg_id, const SbgBinaryLogData &ref_sbg_log);
+  void publish(SbgEComClass sbg_msg_class, SbgEComMsgId sbg_msg_id, const SbgBinaryLogData &ref_sbg_log);
 };
 }
 

--- a/include/sbg_driver/message_wrapper.h
+++ b/include/sbg_driver/message_wrapper.h
@@ -276,10 +276,8 @@ public:
   /*!
    * Set the wrapper processing ROS time.
    * This method is call on the SbgDevice periodic handle, in order to have the same processing time for the messages.
-   * 
-   * \param[in] ref_ros_time        ROS processing time to set.
    */
-  void setRosProcessingTime(const ros::Time& ref_ros_time);
+  void setRosProcessingTime(void);
 
   //---------------------------------------------------------------------//
   //- Operations                                                        -//

--- a/include/sbg_driver/sbg_device.h
+++ b/include/sbg_driver/sbg_device.h
@@ -84,8 +84,6 @@ private:
   ros::ServiceServer      m_calib_service_;
   ros::ServiceServer      m_calib_save_service_;
 
-  ros::Time               m_ros_processing_time_;
-
   //---------------------------------------------------------------------//
   //- Private  methods                                                  -//
   //---------------------------------------------------------------------//

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -367,6 +367,7 @@ void MessagePublisher::publishIMUData(const SbgBinaryLogData &ref_sbg_log)
   if (m_sbgImuData_pub_)
   {
     m_sbg_imu_message_ = m_message_wrapper_.createSbgImuDataMessage(ref_sbg_log.imuData, m_frame_id_);
+
     m_sbgImuData_pub_.publish(m_sbg_imu_message_);
   }
   if (m_temp_pub_)
@@ -515,13 +516,13 @@ void MessagePublisher::initPublishers(ros::NodeHandle& ref_ros_node_handle, cons
   }
 }
 
-void MessagePublisher::publish(const ros::Time& ref_ros_time, SbgEComClass sbg_msg_class, SbgEComMsgId sbg_msg_id, const SbgBinaryLogData &ref_sbg_log)
+void MessagePublisher::publish(SbgEComClass sbg_msg_class, SbgEComMsgId sbg_msg_id, const SbgBinaryLogData &ref_sbg_log)
 {
   //
   // Publish the message with the corresponding publisher and SBG message ID.
   // For each log, check if the publisher has been initialized.
   //
-  m_message_wrapper_.setRosProcessingTime(ref_ros_time);
+  m_message_wrapper_.setRosProcessingTime();
 
   if(sbg_msg_class == SBG_ECOM_CLASS_LOG_ECOM_0)
   {

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -321,9 +321,9 @@ const sbg_driver::SbgAirDataStatus MessageWrapper::createAirDataStatusMessage(co
 //- Parameters                                                        -//
 //---------------------------------------------------------------------//
 
-void MessageWrapper::setRosProcessingTime(const ros::Time& ref_ros_time)
+void MessageWrapper::setRosProcessingTime(void)
 {
-  m_ros_processing_time_ = ref_ros_time;
+  m_ros_processing_time_ = ros::Time::now();
 }
 
 //---------------------------------------------------------------------//

--- a/src/sbg_device.cpp
+++ b/src/sbg_device.cpp
@@ -114,7 +114,7 @@ void SbgDevice::onLogReceived(SbgEComClass msg_class, SbgEComMsgId msg, const Sb
   //
   // Publish the received SBG log.
   //
-  m_message_publisher_.publish(m_ros_processing_time_, msg_class, msg, ref_sbg_data);
+  m_message_publisher_.publish(msg_class, msg, ref_sbg_data);
 }
 
 void SbgDevice::loadParameters(void)
@@ -492,7 +492,5 @@ void SbgDevice::initDeviceForMagCalibration(void)
 
 void SbgDevice::periodicHandle(void)
 {
-  m_ros_processing_time_ = ros::Time::now();
-
   sbgEComHandle(&m_com_handle_);
 }


### PR DESCRIPTION
Stamp is set in the publish method of the sbg_publisher instead of set it in the periodicHandle method of the sbg_device .

Each times a message is parsed by the SBGECOM library, the stamp of the message is set and then the message is publish instead of read the timestamp then parse each messages and use this timestamp to set the stamp of each parsed messages.